### PR TITLE
Home: collapse "What's On" to one centered column when only events OR specials

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -158,6 +158,10 @@ export default function Home() {
     const draftBeers = onTapBeers.slice(0, 4);
     const activeEvents = events.filter((e) => e.active).slice(0, 2);
     const activeSpecials = specials.filter((s) => s.active).slice(0, 2);
+    // Only split into two columns when BOTH have content — otherwise a lone
+    // column leaves the other half of the grid an empty block.
+    const bothEventColumns =
+        activeEvents.length > 0 && activeSpecials.length > 0;
 
     // Pull prices from Supabase, use shortened ingredient descriptions
     const cocktailItems = FEATURED_COCKTAILS.map((featured) => {
@@ -367,7 +371,13 @@ export default function Home() {
                             subtitle="Live music, drag shows, seasonal cocktails — there's always something going on."
                         />
 
-                        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-12">
+                        <div
+                            className={`mt-12 ${
+                                bothEventColumns
+                                    ? 'grid grid-cols-1 lg:grid-cols-2 gap-8'
+                                    : 'max-w-2xl mx-auto'
+                            }`}
+                        >
                             {/* Events column */}
                             {activeEvents.length > 0 && (
                                 <div className="space-y-4">


### PR DESCRIPTION
## Public-site (iggysseaside) layout fix

The homepage **"What's On"** section was a hardcoded 2-column grid (Events | Specials). When only one side had active content, the other half rendered as an **empty block**.

This makes the layout conditional:
- Both events **and** specials active → 2-column grid (unchanged)
- Only one active → a single centered `max-w-2xl` column

**Scope:** one file (`src/pages/Home.tsx`, +11/−1). Public marketing site only — no manager-app, backend, or data changes. Separated from the manager-app work in #17 so the customer-facing change ships on its own.

> This change pre-existed uncommitted in the working tree; isolated and committed as-is after verifying the public site builds clean (`tsc -b && vite build`).

### Test plan
- `npm run build` (root) → clean ✅
- Review the Netlify deploy preview for **iggysseaside** before merge — check the section with (a) both columns, (b) only events, (c) only specials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2ZijJx4mpAqAiMs5diVmR